### PR TITLE
🚑 🐞 JSON-API transform should happen for empty shipment sets too

### DIFF
--- a/src/Http/Middleware/TransformsToJsonApi.php
+++ b/src/Http/Middleware/TransformsToJsonApi.php
@@ -24,6 +24,10 @@ class TransformsToJsonApi
 
         $originalControllerResponse = $response->getOriginalContent();
 
+        if (empty($originalControllerResponse)) {
+            return new JsonResponse(['data' => []]);
+        }
+
         if (!$this->containsShipments($originalControllerResponse)) {
             return $response;
         }

--- a/tests/Http/Middleware/TransformsToJsonApiTest.php
+++ b/tests/Http/Middleware/TransformsToJsonApiTest.php
@@ -62,4 +62,21 @@ class TransformsToJsonApiTest extends TestCase
             ],
         ], $middleware->handle($requestMock, $next)->getOriginalContent());
     }
+
+    public function test_it_should_transform_if_original_content_is_empty(): void
+    {
+        $middleware = new TransformsToJsonApi();
+
+        $responseMock = Mockery::mock(JsonResponse::class, [
+            'getOriginalContent' => [],
+        ]);
+
+        $next = static fn() => $responseMock;
+
+        $requestMock = Mockery::mock(Request::class);
+
+        self::assertEquals([
+            'data' => [],
+        ], $middleware->handle($requestMock, $next)->getOriginalContent());
+    }
 }


### PR DESCRIPTION
# Changes
When no shipments were returned the middleware should still transform the response to:
```json
{
  "data": []
}
```